### PR TITLE
Add AppVeyor badge and streamline Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 jdk:
   - oraclejdk8
-sudo: required
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libaio1
+addons:
+  apt:
+    packages:
+    - libaio-dev
 script: mvn verify -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+  - openjdk7
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+[![Travis build status](https://img.shields.io/travis/mike10004/common-helper.svg)](https://travis-ci.org/mike10004/common-helper)
+[![AppVeyor build status](https://img.shields.io/appveyor/ci/mike10004/common-helper.svg)](https://ci.appveyor.com/project/mike10004/common-helper)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.mike10004/common-helper.svg)](https://repo1.maven.org/maven2/com/github/mike10004/common-helper/)
-[![Build Status](https://img.shields.io/travis/mike10004/common-helper.svg)](https://travis-ci.org/mike10004/common-helper)
 
 Common Helper Libraries
 =======================

--- a/imnetio-helper/pom.xml
+++ b/imnetio-helper/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.mike10004</groupId>
         <artifactId>common-helper</artifactId>
-        <version>4.2.0</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>imnetio-helper</artifactId>
     <packaging>jar</packaging>

--- a/native-helper/pom.xml
+++ b/native-helper/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.mike10004</groupId>
         <artifactId>common-helper</artifactId>
-        <version>4.2.0</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>native-helper</artifactId>
     <name>native-helper</name>

--- a/native-helper/src/main/java/com/github/mike10004/nativehelper/Program.java
+++ b/native-helper/src/main/java/com/github/mike10004/nativehelper/Program.java
@@ -224,16 +224,6 @@ public abstract class Program<R extends ProgramResult> {
             taskFactory = new DefaultTaskFactory();
         }
         
-        protected static void copyFields(Builder src, Builder dst) {
-            checkArgument(!dst.getClass().isAssignableFrom(src.getClass()), "expected destination instance to be a proper subclass of source class");
-            dst.arguments.clear();
-            dst.arguments.addAll(src.arguments);
-            dst.standardInput = src.standardInput;
-            dst.standardInputFile = src.standardInputFile;
-            dst.workingDirectory = src.workingDirectory;
-            dst.taskFactory = src.taskFactory;
-        }
-        
         /**
          * Feeds the given string to the process's standard input stream.
          * @param standardInputString the input string

--- a/native-helper/src/test/java/com/novetta/ibg/common/sys/AntExecutorTest.java
+++ b/native-helper/src/test/java/com/novetta/ibg/common/sys/AntExecutorTest.java
@@ -26,6 +26,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author mchaberski
  */
+@SuppressWarnings("deprecation")
 public class AntExecutorTest {
     
     @Rule

--- a/ormlite-helper-testtools/pom.xml
+++ b/ormlite-helper-testtools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.mike10004</groupId>
         <artifactId>common-helper</artifactId>
-        <version>4.2.0</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>ormlite-helper-testtools</artifactId>
     <name>ormlite-helper-testtools</name>

--- a/ormlite-helper/pom.xml
+++ b/ormlite-helper/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.mike10004</groupId>
         <artifactId>common-helper</artifactId>
-        <version>4.2.0</version>
+        <version>4.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>ormlite-helper</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.mike10004</groupId>
     <artifactId>common-helper</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>common-helper</name>
     <description>Helper library for common computing tasks</description>


### PR DESCRIPTION
* add appveyor badge to readme
* use apt addon for Travis (no sudo required; allows container usage)
* make travis build in oraclejdk8 and openjdk7
